### PR TITLE
Sort playlists by name

### DIFF
--- a/spotify-backup.py
+++ b/spotify-backup.py
@@ -142,6 +142,7 @@ def main():
 
 	# List all playlists and all track in each playlist.
 	playlists = spotify.list('users/{user_id}/playlists'.format(user_id=me['id']), {'limit': 50})
+	playlists.sort(key=lambda playlist: playlist['name'])
 	for playlist in playlists:
 		log('Loading playlist: {name} ({tracks[total]} songs)'.format(**playlist))
 		playlist['tracks'] = spotify.list(playlist['tracks']['href'], {'limit': 100})


### PR DESCRIPTION
Sort playlists by name before dumping.

This way, the output is more predictable. If you track the backup in git, the diffs take up less space, and you can trace the changes more easily.