### PR TITLE
Log request count

### DIFF
--- a/spotify-backup.py
+++ b/spotify-backup.py
@@ -45,6 +45,10 @@ class SpotifyAPI:
 	# fetches all pages and joins them, returning in a single list of objects.
 	def list(self, url, params={}):
 		response = self.get(url, params)
+		requests = int(response['total'] / params['limit'])
+		if requests > 10:
+			timeEstimate = int(0.27*requests); # in seconds, 0.28 was the average speed of 130 requests
+			log('{} items, {} items per request, {} requests, ~{} seconds'.format(response['total'], params['limit'], requests, timeEstimate))
 		items = response['items']
 		while response['next']:
 			response = self.get(response['next'])


### PR DESCRIPTION
For large playlists (6500 songs) this method can take over a minute. To avoid wrong conclusions because the program 'is doing nothing' the number of items and needed requests is logged/printed.