### PR TITLE
Fixed crash when track missing all its info

### DIFF
--- a/spotify-backup.py
+++ b/spotify-backup.py
@@ -188,6 +188,8 @@ def main():
 			for playlist in playlists:
 				f.write(playlist['name'] + '\r\n')
 				for track in playlist['tracks']:
+					if track['track'] is None:
+						continue
 					f.write('{name}\t{artists}\t{album}\t{uri}\r\n'.format(
 						uri=track['track']['uri'],
 						name=track['track']['name'],


### PR DESCRIPTION
Spotify's API gave out a track that looked like this:
```
      {     
        "added_at": "2020-02-14T17:31:47Z",
        "added_by": {
          "external_urls": {
            "spotify": "https://open.spotify.com/user/"
          },    
          "href": "https://api.spotify.com/v1/users/",
          "id": "",
          "type": "user",
          "uri": "spotify:user:"
        },    
        "is_local": false,
        "primary_color": null, 
        "track": null, 
        "video_thumbnail": null
      },
```

As 'track' is null, the playlist save crashes when using tab-separated mode.

This change ignores tracks with 'null' info.
