### PR TITLE
Add plain-txt output format and change newline character

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,15 +3,19 @@ spotify-backup
 
 A Python script that exports all of your Spotify playlists, useful for paranoid Spotify users like me, afraid that one day Spotify will go under and take all of our playlists with it!
 
-To run the script, [save it from here](https://raw.githubusercontent.com/caseychu/spotify-backup/master/spotify-backup.py) and double-click it. It'll ask you for a filename and then pop open a web page so you can authorize access to the Spotify API. Then the script will load your playlists and save a tab-separated file with your playlists that you can open in Excel. You can even copy-paste the rows from Excel into a Spotify playlist.
+To run the script, [save it from here](https://raw.githubusercontent.com/caseychu/spotify-backup/master/spotify-backup.py) and double-click it. It'll ask you for a filename and then pop open a web page so you can authorize access to the Spotify API. Then the script will load your playlists and save a tab-separated file with your playlists that you can open in Excel. You can even copy-paste the rows from Excel into a Spotify playlist. For ease of import into other music streaming services, you can choose to output titles and artists only, in the format of `TITLE - ARTIST`.
 
 You can run the script from the command line:
 
     python spotify-backup.py playlists.txt
 
-or, to get a JSON dump, use:
+To get a JSON dump, use:
 
     python spotify-backup.py playlists.json --format=json
+
+To output titles and artists only, use:
+    
+    python spotify-backup.py playlists.txt --format=plain-txt
 
 By default, it includes your playlists. To include your Liked Songs, you can use:
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ spotify-backup
 
 A Python script that exports all of your Spotify playlists, useful for paranoid Spotify users like me, afraid that one day Spotify will go under and take all of our playlists with it!
 
-To run the script, [save it from here](https://raw.githubusercontent.com/caseychu/spotify-backup/master/spotify-backup.py) and double-click it. It'll ask you for a filename and then pop open a web page so you can authorize access to the Spotify API. Then the script will load your playlists and save a tab-separated file with your playlists that you can open in Excel. You can even copy-paste the rows from Excel into a Spotify playlist. For ease of import into other music streaming services, you can choose to output titles and artists only, in the format of `TITLE - ARTIST`.
+To run the script, [save it from here](https://raw.githubusercontent.com/caseychu/spotify-backup/master/spotify-backup.py) and double-click it. It'll ask you for a filename and then pop open a web page so you can authorize access to the Spotify API. Then the script will load your playlists and save a tab-separated file with your playlists that you can open in Excel. You can even copy-paste the rows from Excel into a Spotify playlist. For ease of import into other music streaming services, you can choose to output titles and artist names only, in the format of `<title> - <artist name>`.
 
 You can run the script from the command line:
 

--- a/spotify-backup.py
+++ b/spotify-backup.py
@@ -135,7 +135,7 @@ def main():
 	                                                         + '`playlist-read-private` permission)')
 	parser.add_argument('--dump', default='playlists', choices=['liked,playlists', 'playlists,liked', 'playlists', 'liked'],
 	                    help='dump playlists or liked songs, or both (default: playlists)')
-	parser.add_argument('--format', default='txt', choices=['json', 'txt'], help='output format (default: txt)')
+	parser.add_argument('--format', default='txt', choices=['json', 'txt', 'plain-txt'], help='output format (default: txt)')
 	parser.add_argument('file', help='output filename', nargs='?')
 	args = parser.parse_args()
 	
@@ -190,22 +190,26 @@ def main():
 		
 		# Tab-separated file.
 		else:
-			f.write('Playlists: \r\n\r\n')
+			f.write('Playlists:\n\n')
 			for playlist in playlists:
-				f.write(playlist['name'] + '\r\n')
+				f.write(playlist['name'] + '\n\n')
 				for track in playlist['tracks']:
 					if track['track'] is None:
 						continue
-					f.write('{name}\t{artists}\t{album}\t{uri}\t{release_date}\r\n'.format(
-						uri=track['track']['uri'],
-						name=track['track']['name'],
-						artists=', '.join([artist['name'] for artist in track['track']['artists']]),
-						album=track['track']['album']['name'],
-						release_date=track['track']['album']['release_date']
-					))
-				f.write('\r\n')
+					uri=track['track']['uri']
+					name=track['track']['name']
+					artists=', '.join([artist['name'] for artist in track['track']['artists']])
+					release_date=track['track']['album']['release_date']
+					album=track['track']['album']['name']
+
+					if args.format == 'txt':
+						f.write(f'{name}\t{artists}\t{album}\t{uri}\t{release_date}\n')
+					else:
+						f.write(f'{name} - {artists}\n')
+				f.write('\n')
+
 			if len(liked_albums) > 0:
-				f.write('Liked Albums: \r\n\r\n')
+				f.write('Liked Albums: \n')
 				for album in liked_albums:
 					uri = album['album']['uri']
 					name = album['album']['name']
@@ -213,7 +217,10 @@ def main():
 					release_date = album['album']['release_date']
 					album = f'{artists} - {name}'
 
-					f.write(f'{name}\t{artists}\t-\t{uri}\t{release_date}\r\n')
+					if args.format == 'txt':
+						f.write(f'{name}\t{artists}\t-\t{uri}\t{release_date}\n')
+					else:
+						f.write(f'{name} - {artists}\n')
 
 	logging.info('Wrote file: ' + args.file)
 

--- a/spotify-backup.py
+++ b/spotify-backup.py
@@ -192,7 +192,7 @@ def main():
 		else:
 			f.write('Playlists:\n\n')
 			for playlist in playlists:
-				f.write(playlist['name'] + '\n\n')
+				f.write(playlist['name'] + '\n')
 				for track in playlist['tracks']:
 					if track['track'] is None:
 						continue


### PR DESCRIPTION
For ease of import into other streaming services, added a new output format called `plain-txt` that only outputs song titles and artist names, like this: `<title> - <artist name>`.

Also, here's an excerpt from the Python documentation on the `open` method:
> When writing output to the stream, if _newline_ is None, any `'\n'` characters written are translated to the system default line separator, [os.linesep](https://docs.python.org/3/library/os.html#os.linesep). If newline is `''` or `'\n'`, no translation takes place. If newline is any of the other legal values, any `'\n'` characters written are translated to the given string.

So, when writing to the file, `\n` should probably be used instead of `\r\n` for cross-platform support.