### PR TITLE
Extend needed permissions for OAuth token

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,6 @@ By default, it includes your playlists. To include your Liked Songs, you can use
     python spotify-backup.py playlists.txt --dump=liked,playlists
 
 
-If for some reason the browser-based authorization flow doesn't work, you can also [generate an OAuth token](https://developer.spotify.com/web-api/console/get-playlists/) on the developer site (with the `playlist-read-private` permission) and pass it with the `--token` option.
+If for some reason the browser-based authorization flow doesn't work, you can also [generate an OAuth token](https://developer.spotify.com/web-api/console/get-playlists/) on the developer site (with the `playlist-read-private`, `playlist-read-collaborative` and `user-library-read` permissions) and pass it with the `--token` option.
 
 Collaborative playlists and playlist folders don't show up in the API, sadly.

--- a/spotify-backup.py
+++ b/spotify-backup.py
@@ -132,7 +132,7 @@ def main():
 	                                           + 'to authorize the Spotify Web API, but you can also manually specify'
 	                                           + ' an OAuth token with the --token option.')
 	parser.add_argument('--token', metavar='OAUTH_TOKEN', help='use a Spotify OAuth token (requires the '
-	                                                         + '`playlist-read-private` permission)')
+	                                                         + '`playlist-read-private`, `playlist-read-collaborative` and `user-library-read`  permissions)')
 	parser.add_argument('--dump', default='playlists', choices=['liked,playlists', 'playlists,liked', 'playlists', 'liked'],
 	                    help='dump playlists or liked songs, or both (default: playlists)')
 	parser.add_argument('--format', default='txt', choices=['json', 'txt'], help='output format (default: txt)')


### PR DESCRIPTION
To use the Oauth Token aswell for `--dump=liked` the permissions need to extended, otherwise the request is forbidden by Spotify

```
Couldn't load URL: https://api.spotify.com/v1/users/xxxxxxxxxx/tracks?limit=50 (HTTP Error 403: Forbidden)
```