### PR TITLE
explicitly use `python3` in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,15 +7,15 @@ To run the script, [save it from here](https://raw.githubusercontent.com/caseych
 
 You can run the script from the command line:
 
-    python spotify-backup.py playlists.txt
+    python3 spotify-backup.py playlists.txt
 
 or, to get a JSON dump, use:
 
-    python spotify-backup.py playlists.json --format=json
+    python3 spotify-backup.py playlists.json --format=json
 
 By default, it includes your playlists. To include your Liked Songs, you can use:
 
-    python spotify-backup.py playlists.txt --dump=liked,playlists
+    python3 spotify-backup.py playlists.txt --dump=liked,playlists
 
 
 If for some reason the browser-based authorization flow doesn't work, you can also [generate an OAuth token](https://developer.spotify.com/web-api/console/get-playlists/) on the developer site (with the `playlist-read-private` permission) and pass it with the `--token` option.


### PR DESCRIPTION
Fixes #39.
As somebody mentioned there, defaulting to `python2` when `python` is invoked is still rather common.