### PR TITLE
switch/update api endpoint for liked songs

### DIFF
--- a/spotify-backup.py
+++ b/spotify-backup.py
@@ -162,7 +162,7 @@ def main():
 	# List liked albums and songs
 	if 'liked' in args.dump:
 		logging.info('Loading liked albums and songs...')
-		liked_tracks = spotify.list('users/{user_id}/tracks'.format(user_id=me['id']), {'limit': 50})
+		liked_tracks = spotify.list('me/tracks', {'limit': 50})
 		liked_albums = spotify.list('me/albums', {'limit': 50})
 		playlists += [{'name': 'Liked Songs', 'tracks': liked_tracks}]
 


### PR DESCRIPTION
Spotify changed the api endpoint for getting liked songs. The old path is responding 404.
 
Referring to https://developer.spotify.com/documentation/web-api/reference/get-users-saved-tracks I changed it to `me/tracks` which make it work again.

```
[08:24:46] Loading liked albums and songs...
[08:24:46] Couldn't load URL: https://api.spotify.com/v1/users/xxxxx/tracks?limit=50 (HTTP Error 404: Not Found)
[08:24:48] Trying again...
[08:24:49] Couldn't load URL: https://api.spotify.com/v1/users/xxxxx/tracks?limit=50 (HTTP Error 404: Not Found)
[08:24:51] Trying again...
[08:24:51] Couldn't load URL: https://api.spotify.com/v1/users/xxxxx/tracks?limit=50 (HTTP Error 404: Not Found)
[08:24:53] Trying again...
```

After fix:
```
[08:30:47] Loading liked albums and songs...
[08:31:02] Loaded 1550/3075 items
[08:31:16] Scrubbing cruft...
[08:31:16] Writing files...
```
